### PR TITLE
Add standby failover service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ C:\minio\minio.exe server C:\minio-data --console-address ":9001"
 6. 查看控制台输出和本地数据库内容，确认数据与主机一致。
 7. 如需持续同步，可在第二台机也启动 Litestream 服务，指向同一 MinIO 存储。
 
+## 9. 自动故障转移示例
+
+项目新增了 `myapp.standby`，用于在候选节点上定期检查主节点是否存活。如果检测到
+`http://localhost:3001/health` 无响应，将自动执行 `litestream restore` 恢复数
+据并启动本地服务接管。
+
+```bash
+clojure -M:standby
+```
+
+启动后程序会每 5 秒轮询一次主节点，一旦发现故障便会拉起自己的 HTTP 服务和写入任
+务。
+
 ## 工作原理与热备场景
 
 在生产环境中可以将 MinIO 部署为共享服务，或在每台主机上独立运行。本项目采用后者，即每台主机都拥有自己的 MinIO 实例，并通过交叉复制实现热备。

--- a/deps.edn
+++ b/deps.edn
@@ -3,5 +3,6 @@
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.925"}
        org.xerial/sqlite-jdbc {:mvn/version "3.46.0.0"}
        http-kit/http-kit {:mvn/version "2.7.0"}}
- :aliases {:run {:main-opts ["-m" "myapp.db"]}
-           :service {:main-opts ["-m" "myapp.service"]}}}
+  :aliases {:run {:main-opts ["-m" "myapp.db"]}
+            :service {:main-opts ["-m" "myapp.service"]}
+            :standby {:main-opts ["-m" "myapp.standby"]}}}

--- a/src/myapp/standby.clj
+++ b/src/myapp/standby.clj
@@ -1,0 +1,38 @@
+(ns myapp.standby
+  (:require [myapp.db :as db]
+            [myapp.service :as service]
+            [clojure.java.shell :as shell]
+            [org.httpkit.client :as client]))
+
+(def health-url "http://localhost:3001/health")
+
+(defn port-active? []
+  (try
+    (let [{:keys [status]} @(client/get health-url {:timeout 2000})]
+      (= 200 status))
+    (catch Exception _ false)))
+
+(defn restore-db []
+  (println "Restoring SQLite database via Litestream...")
+  (let [{:keys [exit err]} (shell/sh "litestream" "restore" "-o" "app-data.db" "s3://clojure-db-replica/database")]
+    (if (zero? exit)
+      (println "Restore completed.")
+      (println "Restore failed:" err))
+    (zero? exit)))
+
+(defn start-service []
+  (db/initialize-database!)
+  (service/start-server)
+  (service/start-writer)
+  (println "Service running as primary. Press Ctrl+C to exit.")
+  @(promise))
+
+(defn -main [& _]
+  (println "Standby instance started. Monitoring active service...")
+  (loop []
+    (if (port-active?)
+      (do (Thread/sleep 5000) (recur))
+      (do
+        (println "Active service unreachable. Initiating failover...")
+        (when (restore-db)
+          (start-service))))))


### PR DESCRIPTION
## Summary
- add standby failover logic that checks the active node
- add `:standby` alias for running the new service
- document automatic failover in README

## Testing
- `clojure -M:standby` *(fails: `bash: clojure: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d884784488327846125d1e99e7fb9