### PR TITLE
更新部署到clojars的地址，配置版本等，增加本地打包和部署到clojars的readme

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,18 +11,30 @@
                                org.clojure/test.check {:mvn/version "1.1.1"}
                                clj-http-lite/clj-http-lite {:mvn/version "0.3.0"}
                                org.clojure/data.json {:mvn/version "2.5.0"}}
-                  :main-opts ["-m" "runner"]}}
+                  :main-opts ["-m" "runner"]}
+            :create-pom {:extra-deps {io.github.seancorfield/depstar {:mvn/version "2.2.216"}}
+                         :exec-fn hf.depstar.api/pom
+                         :exec-args {}} ; Default args ensure it uses :pom-data from deps.edn
+            :package {:extra-deps {io.github.seancorfield/depstar {:mvn/version "2.2.216"}}
+                      :exec-fn hf.depstar.api/jar
+                      :exec-args {:pom-file "pom.xml"}} ; Assumes pom.xml is generated
+            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
+                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
+                                 ;; deps-deploy will use pom.xml found in the project root
+                                 ;; and infer the JAR from the pom.
+                                 ;; Add --sign-releases and --gpg-key if signing.
+                                ]}}}
  :pom-data {:lib 'net.clojars.zhaoyul/sqlite-replicate
             :version "0.1.0-SNAPSHOT"
             :description "A library for SQLite replication using Litestream and MinIO."
-            :url "https://github.com/your-username/sqlite-replicate"
+            :url "https://github.com/RedCreationTech/sqlite-replicate"
             :licenses [:license
                        {:name "Eclipse Public License"
                         :url "http://www.eclipse.org/legal/epl-v10.html"}]
             :developers [:developer
-                         {:name "Your Name"
-                          :email "your.email@example.com"}]
-            :scm {:url "https://github.com/your-username/sqlite-replicate"
-                  :connection "scm:git:git://github.com/your-username/sqlite-replicate.git"
-                  :developer-connection "scm:git:ssh://git@github.com/your-username/sqlite-replicate.git"
+                         {:name "redcreation"
+                          :email "hd@redcreation.cn"}]
+            :scm {:url "https://github.com/RedCreationTech/sqlite-replicate"
+                  :connection "scm:git:git://github.com/RedCreationTech/sqlite-replicate.git"
+                  :developer-connection "scm:git:ssh://git@github.com/RedCreationTech/sqlite-replicate.git"
                   :tag "HEAD"}}}


### PR DESCRIPTION
… in the `deps.edn` file based on your feedback.

Specifically, I've made the following changes to the `:pom-data` section in `deps.edn`:

-   The project URL (`:url`) now points to `https://github.com/RedCreationTech/sqlite-replicate`.
-   The developer information (`:developers`) has been updated to:
    -   name: "redcreation"
    -   email: "hd@redcreation.cn"
-   The SCM information (`:scm`), including the URL, connection, and developer-connection, has been updated to reflect the new GitHub repository address `RedCreationTech/sqlite-replicate`.
-   I've confirmed that the deployment version number (`:version`) remains `"0.1.0-SNAPSHOT"`.

Additionally, I've verified that the example code in your `README.md` for including this library as a dependency, which uses the coordinates `net.clojars.zhaoyul/sqlite-replicate {:mvn/version "0.1.0-SNAPSHOT"}`, is correct and doesn't require any changes.