### PR TITLE
feat: 添加 Litestream 备份与恢复性能测试脚本

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,11 @@
         http-kit/http-kit {:mvn/version "2.7.0"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         org.slf4j/slf4j-api {:mvn/version "2.0.9"}
-        org.slf4j/slf4j-simple {:mvn/version "2.0.9"}}
+        org.slf4j/slf4j-simple {:mvn/version "2.0.9"}
+        ;; Moved from :test alias for CIDER REPL compatibility
+        clj-time/clj-time {:mvn/version "0.15.2"}
+        cheshire/cheshire {:mvn/version "5.13.0"}
+        com.taoensso/timbre {:mvn/version "6.0.1"}}
  :aliases {:run {:main-opts ["-m" "sqlite-replicate.db"]}
            :service {:main-opts ["-m" "sqlite-replicate.service"]}
            :standby {:main-opts ["-m" "sqlite-replicate.standby"]}
@@ -13,11 +17,8 @@
                   :extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                                org.clojure/test.check {:mvn/version "1.1.1"}
                                clj-http-lite/clj-http-lite {:mvn/version "0.3.0"}
-                               org.clojure/data.json {:mvn/version "2.5.0"}
-                               ;; Added for litestream performance testing
-                               clj-time/clj-time {:mvn/version "0.15.2"}
-                               cheshire/cheshire {:mvn/version "5.13.0"}
-                               com.taoensso/timbre {:mvn/version "6.0.1"}}
+                               org.clojure/data.json {:mvn/version "2.5.0"}}
+                               ;; clj-time, cheshire, timbre moved to top-level :deps
                   :main-opts ["-m" "runner"]}
            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
                     :exec-fn deps-deploy.deps-deploy/deploy

--- a/test/runner.clj
+++ b/test/runner.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as test]
             sqlite-replicate.db-test
             sqlite-replicate.service-test
-            sqlite-replicate.standby-test))
+            sqlite-replicate.standby-test
+            sqlite-replicate.litestream-performance-test)) ; Added new performance test namespace
 
 (defn -main [& args]
   (println "Running tests via test runner...")


### PR DESCRIPTION
为 Litestream 添加了一系列性能测试，用于评估在不同数据库大小和写入频率下的备份与恢复时间。 测试使用 Clojure 编写，依赖 MinIO 作为 S3 存储后端。

主要包括：
- `test/sqlite_replicate/perf_test_utils.clj`: 测试辅助函数，包含数据库生成、shell命令执行、Litestream进程管理等功能。
- `test/sqlite_replicate/litestream_performance_test.clj`: 核心测试用例，覆盖静态数据库大小和动态写入频率两种场景。
- 更新 `deps.edn`: 添加了 `clj-time` (时间处理), `cheshire` (JSON数据生成), 和 `com.taoensso/timbre` (日志) 作为测试依赖。为了改善 CIDER REPL 的加载体验，这些依赖被移至顶层 `:deps`。
- `test/runner.clj`: 更新测试运行器以包含新的性能测试命名空间。
- `litestream.yml`: 提供了针对测试优化的配置文件，包括较短的同步和保留间隔。
- 更新 `README.md`: 添加了详细的章节，说明如何准备环境、下载依赖、运行性能测试以及解读测试结果。

所有新增代码均包含中文注释，日志输出也已中文化。
由于沙箱环境限制，测试未在沙箱内完全执行。相关的CIDER加载问题和测试运行器发现问题已通过修改 `deps.edn` 和 `runner.clj` 解决。将由用户在配置完整的环境中运行验证。