### PR TITLE
Fix(test): Update Litestream performance tests

### DIFF
--- a/test/sqlite_replicate/litestream_performance_test.clj
+++ b/test/sqlite_replicate/litestream_performance_test.clj
@@ -9,17 +9,20 @@
             [taoensso.timbre :as timbre])) ; timbre 日志库
 
 ;; --- 测试配置 ---
-(defonce ^{:doc "测试生成的数据库文件名。"}
-  test-db-filename "test-perf-app-data.db")
+(defn- timestamp-suffix []
+  (str "-" (System/currentTimeMillis)))
 
-(defonce ^{:doc "恢复后数据库的文件名。"}
-  restored-db-filename "restored-perf-app-data.db")
+(defn test-db-filename []
+  (str "test-perf-app-data" (timestamp-suffix) ".db"))
+
+(defn restored-db-filename []
+  (str "restored-perf-app-data" (timestamp-suffix) ".db"))
 
 (defonce ^{:doc "Litestream 配置文件的路径 (假设在项目根目录)。"}
   litestream-config-path "./litestream.yml")
 
-(defonce ^{:doc "要测试的数据库大小列表 (MB)。完整列表：[10 50 100 200 300 500 1000]"}
-  db-sizes-mb [0.1 0.25 0.5]) ; 初始测试使用较小的值以加快速度
+(defonce ^{:doc "要测试的数据库大小列表 (MB)。"}
+  db-sizes-mb [10 50 100 200 300 500 1000]) ; 完整列表
 
 (defonce ^{:doc "要测试的写入频率列表 (Hz)。完整列表：[1 10]"}
   write-frequencies-hz [1 2]) ; 初始测试使用较小的值
@@ -41,14 +44,23 @@
   [f]
   (timbre/info "\n=== 测试 Fixture 设置 (已调整以适应 litestream.yml 路径) ===")
   (utils/clear-minio-bucket-path)
-  (utils/clear-db-file test-db-filename) ; 测试专用的、动态生成的数据库文件
+  ;; 注意：由于文件名现在是动态生成的，启动时的清理可能无法捕获特定文件名
+  ;; 但在测试执行期间会使用动态名称。
+  ;; (utils/clear-db-file (test-db-filename)) ; 如果需要清理特定模式的文件，需要更复杂的逻辑
   (utils/clear-db-file utils/default-db-filename) ; litestream.yml 实际监控的文件
-  (utils/clear-db-file restored-db-filename) ; 恢复测试用的文件
+  ;; (utils/clear-db-file (restored-db-filename)) ; 动态名称，按需清理或保留
+
+  ;; 在测试开始前，按前缀清理上一次测试可能遗留的文件
+  (utils/clear-db-files-by-prefix "test-perf-app-data-")
+  (utils/clear-db-files-by-prefix "restored-perf-app-data-")
+
   (f) ; 执行测试主体
   (timbre/info "=== 测试 Fixture 清理 (已调整) ===")
-  (utils/clear-db-file test-db-filename)
-  (utils/clear-db-file utils/default-db-filename)
-  (utils/clear-db-file restored-db-filename))
+  ;; 清理逻辑将保留文件，因此以下行被注释或移除
+  ;; (utils/clear-db-file (test-db-filename)) ; 保留
+  (utils/clear-db-file utils/default-db-filename) ; 这个是 litestream 监控的，通常需要清理以备下次运行
+  ;; (utils/clear-db-file (restored-db-filename)) ; 保留
+  )
 
 ;; 使用 :once Fixture，它会在当前命名空间所有测试运行前执行一次 setup，所有测试结束后执行一次 teardown。
 ;; 如果每个 deftest 需要更严格的隔离，可以使用 :each。
@@ -60,25 +72,29 @@
   (timbre/info "\n--- 开始测试：静态数据库备份与恢复性能 (已调整) ---")
   (doseq [target-size-mb db-sizes-mb]
     (testing (str "数据库大小: " target-size-mb " MB")
-      (timbre/info (format "--- 测试场景：静态数据库，目标大小 %.2f MB ---" target-size-mb))
-      (utils/clear-minio-bucket-path) ; 确保每次测试大小前 MinIO 存储桶是干净的
-      (utils/clear-db-file test-db-filename)
-      (utils/clear-db-file utils/default-db-filename)
-      (utils/clear-db-file restored-db-filename)
+      (let [current-test-db (test-db-filename)
+            current-restored-db (restored-db-filename)]
+        (timbre/info (format "--- 测试场景：静态数据库，目标大小 %.2f MB (测试DB: %s, 恢复DB: %s) ---"
+                             target-size-mb current-test-db current-restored-db))
+        (utils/clear-minio-bucket-path) ; 确保每次测试大小前 MinIO 存储桶是干净的
+        (utils/clear-db-file current-test-db)
+        (utils/clear-db-file utils/default-db-filename)
+        (utils/clear-db-file current-restored-db)
 
-      (let [original-size-mb (utils/populate-db-to-size test-db-filename target-size-mb) ; 生成测试数据库
-            _ (is (some? original-size-mb) (str "原始数据库 " test-db-filename " 应当成功创建"))
-            _ (timbre/info (format "原始数据库 '%s' 已创建，实际大小: %.2f MB" test-db-filename original-size-mb))]
+        (let [original-size-mb (utils/populate-db-to-size current-test-db target-size-mb) ; 生成测试数据库
+              _ (is (some? original-size-mb) (str "原始数据库 " current-test-db " 应当成功创建"))
+              _ (timbre/info (format "原始数据库 '%s' 已创建，实际大小: %.2f MB" current-test-db original-size-mb))]
 
-        ; 将生成的测试数据库复制到 litestream 监控的路径
-        (copy-file test-db-filename utils/default-db-filename)
+          ; 将生成的测试数据库复制到 litestream 监控的路径
+          (copy-file current-test-db utils/default-db-filename)
         (is (.exists (io/file utils/default-db-filename)) "数据库文件应当已复制到 Litestream 的监控路径")
 
         (timbre/info "启动 Litestream replicate 进行备份...")
         (let [ls-process (utils/start-litestream-replicate litestream-config-path)]
           (is (some? ls-process) "Litestream replicate 进程应当成功启动")
-          (timbre/info "等待 Litestream 完成初始同步 (根据 sync-interval 和 snapshot-interval 调整等待时间)...")
-          (Thread/sleep 5000) ; 等待 5 秒，确保至少一次同步和快照（如果配置较快）
+          (timbre/info "等待 Litestream 完成初始同步 (snapshot-interval 默认10s, sync-interval 默认1s)...")
+          (timbre/info "将等待 15 秒以确保至少一个快照周期完成。")
+          (Thread/sleep 15000) ; 增加等待时间至 15 秒
           (utils/stop-litestream-process ls-process)
           (timbre/info "Litestream replicate 进程已停止。"))
 
@@ -87,11 +103,12 @@
         (is (not (.exists (io/file utils/default-db-filename))) "被 Litestream 监控的数据库文件应当在恢复前被删除")
 
         (timbre/info "正在从 Litestream 恢复数据库...")
-        (let [restore-result (utils/litestream-restore restored-db-filename litestream-config-path) ; 将备份恢复到 restored-db-filename
-              restored-size-mb (utils/get-file-size-mb restored-db-filename)]
+        (let [restore-result (utils/litestream-restore current-restored-db litestream-config-path) ; 将备份恢复到 current-restored-db
+              restored-size-mb (utils/get-file-size-mb current-restored-db)]
           (is (:success restore-result) "Litestream restore 命令应当成功执行。")
-          (is (some? restored-size-mb) (str "恢复后的数据库 " restored-db-filename " 应当存在"))
-          (timbre/info (format "数据库恢复完成，耗时 %.2f ms。恢复后的文件大小: %.2f MB"
+          (is (some? restored-size-mb) (str "恢复后的数据库 " current-restored-db " 应当存在"))
+          (timbre/info (format "数据库恢复完成至 '%s'，耗时 %.2f ms。恢复后的文件大小: %.2f MB"
+                               current-restored-db
                                (:duration-ms restore-result)
                                (or restored-size-mb 0)))
 
@@ -132,25 +149,29 @@
 (deftest ^:performance dynamic-db-restore-performance-adjusted
   (timbre/info "\n--- 开始测试：动态数据库 (有持续写入) 恢复性能 (已调整) ---")
   (let [base-db-size-mb 0.1 ; 为动态测试设置一个较小的基础数据库大小，以加快测试: 50MB
-        _ (timbre/info (format "为动态测试准备基础数据库，目标大小 %.2f MB" base-db-size-mb))
-        _ (utils/clear-db-file test-db-filename)
+        current-test-db (test-db-filename) ; 用于基础数据库生成
+        _ (timbre/info (format "为动态测试准备基础数据库 '%s'，目标大小 %.2f MB" current-test-db base-db-size-mb))
+        _ (utils/clear-db-file current-test-db)
         _ (utils/clear-db-file utils/default-db-filename)
-        _ (utils/populate-db-to-size test-db-filename base-db-size-mb)
-        _ (copy-file test-db-filename utils/default-db-filename) ; 初始复制到 Litestream 监控路径
+        _ (utils/populate-db-to-size current-test-db base-db-size-mb)
+        _ (copy-file current-test-db utils/default-db-filename) ; 初始复制到 Litestream 监控路径
         db-spec (utils/get-db-spec utils/default-db-filename) ; 写入操作将发生在这个被监控的数据库上
         ]
 
     (doseq [freq write-frequencies-hz]
       (testing (str "写入频率: " freq " Hz")
-        (timbre/info (format "--- 测试场景：动态数据库，写入频率 %d Hz ---" freq))
-        (utils/clear-minio-bucket-path) ; 为每个频率测试清理 MinIO
+        (let [current-restored-db (restored-db-filename)] ; 每个频率测试恢复到不同的文件
+          (timbre/info (format "--- 测试场景：动态数据库，写入频率 %d Hz (恢复DB: %s) ---" freq current-restored-db))
+          (utils/clear-minio-bucket-path) ; 为每个频率测试清理 MinIO
+          (utils/clear-db-file current-restored-db) ; 清理可能存在的旧恢复文件
 
-        ; 为确保每个频率测试的独立性，重新生成和复制基础数据库
-        (timbre/info "重新生成基础数据库以进行新的频率测试...")
-        (utils/populate-db-to-size test-db-filename base-db-size-mb)
-        (copy-file test-db-filename utils/default-db-filename)
+          ; 为确保每个频率测试的独立性，重新生成和复制基础数据库
+          (timbre/info (format "重新生成基础数据库 '%s' 以进行新的频率测试..." current-test-db))
+          (utils/clear-db-file current-test-db) ; 清理上一次循环的基础DB
+          (utils/populate-db-to-size current-test-db base-db-size-mb)
+          (copy-file current-test-db utils/default-db-filename)
 
-        (let [initial-rows (:count (sql/query (jdbc/get-datasource db-spec) ["SELECT COUNT(*) as count FROM records"]))
+          (let [initial-rows (:count (sql/query (jdbc/get-datasource db-spec) ["SELECT COUNT(*) as count FROM records"]))
               _ (timbre/info (format "数据库 '%s' (被 Litestream 监控) 中的初始行数: %d" utils/default-db-filename initial-rows))]
 
           (timbre/info (str "启动 Litestream replicate 进行动态测试 (频率: " freq " Hz)..."))
@@ -160,8 +181,9 @@
             (timbre/info (format "开始以 %d Hz 的频率向数据库 '%s' 持续写入 %d 秒..." freq utils/default-db-filename continuous-write-duration-seconds))
             (let [writes-performed (perform-writes db-spec freq continuous-write-duration-seconds)]
               (timbre/info (format "在数据库 '%s' 中执行了 %d 次写入操作。" writes-performed utils/default-db-filename))
-              (timbre/info "等待 Litestream 同步最后的更改...")
-              (Thread/sleep 2000) ; 等待 2 秒，让 Litestream 同步最后的数据
+              (timbre/info "等待 Litestream 同步最后的更改 (sync-interval 默认1s)...")
+              (timbre/info "将等待 5 秒以确保最后的写入操作被同步。")
+              (Thread/sleep 5000) ; 增加等待时间至 5 秒
               (utils/stop-litestream-process ls-process)
               (timbre/info "Litestream replicate 进程已为动态测试停止。")
 
@@ -174,16 +196,17 @@
               (is (not (.exists (io/file utils/default-db-filename))) "被监控的数据库文件应当在恢复前被删除 (动态测试)")
 
               (timbre/info "正在从 Litestream 恢复动态写入后的数据库...")
-              (let [restore-result (utils/litestream-restore restored-db-filename litestream-config-path)
-                    restored-ds (jdbc/get-datasource (utils/get-db-spec restored-db-filename))
+              (let [restore-result (utils/litestream-restore current-restored-db litestream-config-path)
+                    restored-ds (jdbc/get-datasource (utils/get-db-spec current-restored-db))
                     rows-in-restored-db (:count (sql/query restored-ds ["SELECT COUNT(*) as count FROM records"]))]
                 (is (:success restore-result) "Litestream restore 命令应当成功执行 (动态测试)。")
-                (timbre/info (format "数据库恢复 (动态测试) 完成，耗时 %.2f ms。恢复后的数据库中的行数: %d"
+                (timbre/info (format "数据库恢复 (动态测试) 至 '%s' 完成，耗时 %.2f ms。恢复后的数据库中的行数: %d"
+                                     current-restored-db
                                      (:duration-ms restore-result)
                                      rows-in-restored-db))
                 (is (= (+ initial-rows writes-performed) rows-in-restored-db)
                     "恢复后的数据库应当包含所有基础数据和动态写入的数据行。"))))
-          (timbre/info (format "--- 完成动态数据库测试 (写入频率 %d Hz) ---" freq)))))))
+          (timbre/info (format "--- 完成动态数据库测试 (写入频率 %d Hz) ---" freq))))))))
 
 ;; --- 如何运行测试 ---
 ;;


### PR DESCRIPTION
This commit implements several enhancements to the Litestream performance tests:

1.  Use unique, timestamped database names for each test case to avoid conflicts and allow for easier inspection of individual test run artifacts.
2.  Preserve generated and restored database files after test completion for manual comparison. Old test files are cleaned up by prefix at the beginning of the next test run.
3.  Address test failures related to restored database file size mismatches:
    *   Increased logging in `populate-db-to-size` for better diagnostics of DB generation.
    *   Extended Litestream sync/snapshot wait times to allow for more reliable backup completion.
4.  Expanded the list of tested database sizes to [10, 50, 100, 200, 300, 500, 1000] MB as requested.
5.  Ensured that database restoration times are logged for performance analysis.

These changes aim to improve the reliability, debuggability, and comprehensiveness of the Litestream performance tests. Further validation of file size generation for very large databases and the file size assertion may be needed after running these tests in a full environment.